### PR TITLE
Fix rendering when no search parameter is present in the URL

### DIFF
--- a/src/features/people/PeoplePage/index.js
+++ b/src/features/people/PeoplePage/index.js
@@ -14,6 +14,19 @@ const PeoplePage = () => {
     const peopleData = useSelector(selectPeople);
     const people = peopleData.results;
 
+    if (!searchParams) {
+        return (
+            <Wrapper>
+                <PeopleContainer />
+                <Scrollbar
+                    fetchData={fetchPeople}
+                    setData={setPeople}
+                    selectTotalPages={selectTotalPages}
+                />
+            </Wrapper>
+        );
+    }
+
     if (Array.isArray(people) && people.length === 0) {
         return (<NoResults />)
     }


### PR DESCRIPTION
Add fallback rendering when no search parameter is found in the URL.
If there is no search parameter, the page will render with the default data instead of showing the 'No Results' component.